### PR TITLE
fix: Update Gemini Model and QueryEngine instantiation

### DIFF
--- a/backend/chat/services/ai_service.py
+++ b/backend/chat/services/ai_service.py
@@ -68,7 +68,7 @@ def get_generated_query(question: str) -> dict:
         system_prompt = SYSTEM_PROMPT.format(schema=schema_str)
         
         # 3. Call Gemini
-        model = genai.GenerativeModel("gemini-pro")
+        model = genai.GenerativeModel("gemini-2.5-flash")
         chat = model.start_chat()
         
         # Combine system prompt and user question

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from .serializers import ChatRequestSerializer, ChatResponseSerializer
 from .services import ai_service
-from .services.query_engine import QueryEngine
+from .services.query_engine import engine
 import pandas as pd
 import logging
 
@@ -32,8 +32,7 @@ class ChatView(APIView):
             chart_suggestion = ai_response.get("chart_suggestion", {})
 
             # 2. Execute Query
-            # QueryEngine is a singleton, safe to instantiate
-            engine = QueryEngine() 
+            # engine is imported singleton
             execution_result = engine.execute(pandas_code)
 
             if isinstance(execution_result, dict) and "error" in execution_result:


### PR DESCRIPTION
## Description
Fixes discovered during verification execution:
1. Updated `ai_service.py` to use `gemini-2.5-flash` (previous models were deprecated or 404ing).
2. Fixed `views.py` to correctly usage the singleton `engine` instance instead of re-instantiating `QueryEngine` without arguments.

## Verification
Verified locally with script (not included in PR). Full end-to-end pipeline works.