### PR TITLE
feat: Deploy Django backend to Vercel

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,28 @@
+# Python
+__pycache__/
+*.py[cod]
+*.so
+
+# Virtual environment
+.venv/
+venv/
+
+# Environment variables
+.env
+
+# Django
+db.sqlite3
+*.log
+
+# Data files (now using MongoDB)
+data/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/backend/.vercelignore
+++ b/backend/.vercelignore
@@ -1,0 +1,6 @@
+.venv/
+data/
+__pycache__/
+*.pyc
+db.sqlite3
+.env

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 """
 
 from pathlib import Path
+from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,12 +21,17 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-y@_*3kbyu_dcgd8+$+luf=b_!)8kr^)piia9s^rv#+(&^^*x!$'
+SECRET_KEY = config('DJANGO_SECRET_KEY', default='django-insecure-dev-key-change-in-production')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', default=False, cast=bool)
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    'localhost',
+    '127.0.0.1',
+    '.vercel.app',
+    '.cricketiq.com',
+]
 
 
 # Application definition
@@ -55,14 +61,21 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-# CORS settings for frontend development
+# CORS settings
 CORS_ALLOWED_ORIGINS = [
+    # Local development
     'http://localhost:3000',
     'http://127.0.0.1:3000',
     'http://localhost:5173',
     'http://localhost:5174',
     'http://127.0.0.1:5173',
     'http://127.0.0.1:5174',
+    # Production (update after frontend deployment)
+]
+
+CSRF_TRUSTED_ORIGINS = [
+    'https://*.vercel.app',
+    'https://*.cricketiq.com',
 ]
 
 ROOT_URLCONF = 'config.urls'

--- a/backend/config/wsgi.py
+++ b/backend/config/wsgi.py
@@ -14,3 +14,6 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 
 application = get_wsgi_application()
+
+# Vercel expects an `app` variable
+app = application

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+django>=6.0.1
+djangorestframework>=3.16.1
+google-generativeai>=0.8.6
+pandas>=3.0.0
+pymongo>=4.16.0
+python-decouple>=3.8
+certifi>=2026.1.4

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "config/wsgi.py",
+      "use": "@vercel/python",
+      "config": {
+        "maxLambdaSize": "15mb",
+        "runtime": "python3.12"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "config/wsgi.py"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #45

## Summary

Deploy the CricketIQ Django backend as a serverless WSGI application on Vercel via GitHub integration.

## Changes

- **`vercel.json`** — Vercel deployment config routing all requests through Django's WSGI handler (`@vercel/python`, Python 3.12)
- **`requirements.txt`** — Pip requirements for Vercel's builder (mirrors `pyproject.toml` dependencies)
- **`config/settings.py`** — Production-ready settings:
  - `SECRET_KEY` reads from `DJANGO_SECRET_KEY` env var
  - `DEBUG` reads from env var (default: `False`)
  - `ALLOWED_HOSTS` includes `.vercel.app` and `.cricketiq.com`
  - Added `CSRF_TRUSTED_ORIGINS` for Vercel/production domains
- **`config/wsgi.py`** — Added `app` variable alias for Vercel's Python builder
- **`.vercelignore`** — Excludes `.venv/`, `data/`, `__pycache__/`, `db.sqlite3`, `.env`
- **`.gitignore`** — Standard Python/Django gitignore

## Post-Merge Steps

1. Connect repo to Vercel via GitHub integration
2. Set **Root Directory** to `backend/`
3. Configure environment variables in Vercel dashboard:
   - `GEMINI_API_KEY`, `MONGO_URI`, `MONGO_DB`, `MONGO_COLLECTION_DELIVERYWISE`, `MONGO_COLLECTION_MATCHWISE`, `DJANGO_SECRET_KEY`
4. Test `/api/chat/ask/` endpoint