### PR TITLE
fix: reduce Vercel bundle size (exclude uv.lock, remove pandas)

### DIFF
--- a/backend/.vercelignore
+++ b/backend/.vercelignore
@@ -4,3 +4,5 @@ __pycache__/
 *.pyc
 db.sqlite3
 .env
+uv.lock
+pyproject.toml

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,6 @@
 django>=6.0.1
 djangorestframework>=3.16.1
 google-generativeai>=0.8.6
-pandas>=3.0.0
 pymongo>=4.16.0
 python-decouple>=3.8
 certifi>=2026.1.4


### PR DESCRIPTION
## Hotfix: Vercel deployment exceeding 250MB limit

Vercel detected `uv.lock` and installed all dependencies via `uv` instead of using `requirements.txt`, causing the bundle to exceed 250MB (mainly due to `pandas` + `numpy`).

### Fixes
- Add `uv.lock` and `pyproject.toml` to `.vercelignore` → forces Vercel to use `requirements.txt` (pip)
- Remove `pandas` from `requirements.txt` → legacy CSV dependency, not needed with MongoDB

### Reason for expedited merge
Critical production deployment blocker — Vercel build fails without this fix.